### PR TITLE
Audiotree.0.2.0

### DIFF
--- a/conf/base.yml
+++ b/conf/base.yml
@@ -93,16 +93,16 @@ VolumeNorm.config:
   min_db: -16
   max_db: -16
 
-train/build_transforms.augment:
+train/augment_batch.transforms:
   - VolumeNorm
   - RescaleAudio
   - ShiftPhase
 
-val/build_transforms.augment:
+val/augment_batch.transforms:
   - VolumeNorm
   - RescaleAudio
 
-sample/build_transforms.augment:
+sample/augment_batch.transforms:
   - VolumeNorm
   - RescaleAudio
 

--- a/conf/base.yml
+++ b/conf/base.yml
@@ -114,6 +114,9 @@ SaliencyParams.loudness_cutoff: -40
 SaliencyParams.search_function: SaliencyParams.search_uniform
 
 # Data
+create_dataset.worker_count: 0
+create_dataset.worker_buffer_size: 1
+
 create_dataset.extensions:
   - .wav
   - .flac

--- a/scripts/input_pipeline.py
+++ b/scripts/input_pipeline.py
@@ -35,7 +35,7 @@ def create_dataset(
         assert num_steps is not None and num_steps > 0
         datasource = AudioDataBalancedSource(
             sources=sources,
-            num_steps=num_steps * batch_size,
+            num_records=num_steps * batch_size,
             sample_rate=sample_rate,
             mono=mono,
             duration=duration,
@@ -45,7 +45,7 @@ def create_dataset(
     else:
         datasource = AudioDataSimpleSource(
             sources=sources,
-            num_steps=num_steps * batch_size if num_steps is not None else None,
+            num_records=num_steps * batch_size if num_steps is not None else None,
             sample_rate=sample_rate,
             mono=mono,
             duration=duration,
@@ -64,7 +64,7 @@ def create_dataset(
 
     pygrain_ops = [
         grain.Batch(batch_size=batch_size, drop_remainder=True),
-        ReduceBatchTransform(sample_rate),
+        ReduceBatchTransform(),
     ]
 
     dataloader = grain.DataLoader(
@@ -83,13 +83,12 @@ def create_dataset(
 if __name__ == "__main__":
 
     from tqdm import tqdm
-    from audiotree.transforms import VolumeNorm, RescaleAudio, SwapStereo, InvertPhase
     from absl import logging
 
     logging.set_verbosity(logging.INFO)
 
-    folder1 = "/mnt/c/users/braun/Datasets/dx7/patches-DX7-AllTheWeb-Bridge-Music-Recording-Studio-Sysex-Set-4-Instruments-Bass-Bass3-bass-10-syx-01-SUPERBASS2-note69"
-    folder2 = "/mnt/c/Users/braun/Datasets/dx7/patches-DX7-AllTheWeb-Bridge-Music-Recording-Studio-Sysex-Set-4-Instruments-Accordion-ACCORD01-SYX-06-AKKORDEON-note69"
+    folder1 = "/mnt/d/Datasets/dx7/patches-DX7-AllTheWeb-Bridge-Music-Recording-Studio-Sysex-Set-4-Instruments-Bass-Bass3-bass-10-syx-01-SUPERBASS2-note69"
+    folder2 = "/mnt/d/Datasets/dx7/patches-DX7-AllTheWeb-Bridge-Music-Recording-Studio-Sysex-Set-4-Instruments-Accordion-ACCORD01-SYX-06-AKKORDEON-note69"
 
     sources = {
         "a": [folder1],
@@ -99,23 +98,17 @@ if __name__ == "__main__":
     num_steps = 1000
 
     ds = create_dataset(
+        batch_size=32,
+        sample_rate=44_100,
         sources=sources,
         duration=0.5,
         train=True,
-        batch_size=32,
-        sample_rate=44_100,
         mono=True,
         seed=0,
         num_steps=num_steps,
         extensions=None,
         worker_count=0,
         worker_buffer_size=1,
-        transforms=[
-            VolumeNorm(),
-            RescaleAudio(),
-            SwapStereo(),
-            InvertPhase(),
-        ],
         saliency_params=SaliencyParams(False, 8, -70),
     )
 

--- a/scripts/input_pipeline.py
+++ b/scripts/input_pipeline.py
@@ -1,151 +1,15 @@
-import collections
-import itertools
 from typing import List, Mapping
 
 import argbind
-from audiotree import transforms as transforms_lib
 from audiotree import SaliencyParams
 from audiotree.datasources import (
     AudioDataSimpleSource,
     AudioDataBalancedSource,
 )
 from audiotree.transforms import ReduceBatchTransform
-from functools import partial
 from grain import python as grain
-import jax
-from jax import random
-from jax.experimental import mesh_utils
-from jax.experimental.shard_map import shard_map
-from jax.sharding import NamedSharding, Mesh, PartitionSpec as P
-
-
-# Transforms
-def filter_fn(fn):
-    return (
-        hasattr(fn, "random_map") or hasattr(fn, "map") or hasattr(fn, "np_random_map")
-    )
-
-
-# https://github.com/pseeth/argbind/tree/main/examples/bind_module
-transforms_lib = argbind.bind_module(
-    transforms_lib, "train", "val", filter_fn=filter_fn
-)
 
 SaliencyParams = argbind.bind(SaliencyParams, "train", "val", "test", "sample")
-
-
-@argbind.bind("train", "val", "test", "sample")
-def build_transforms(
-    augment: list[str] = None,
-):
-    """
-    :param augment: A list of str names of Transforms (from ``audiotree.transforms``) such as VolumeNorm
-    :return: a list of instances of the Transforms.
-    """
-
-    def to_transform_instances(transform_classes):
-        instances = []
-        for TransformClass in transform_classes:
-            instance = getattr(transforms_lib, TransformClass)()
-            instances.append(instance)
-        return instances
-
-    if augment is None:
-        augment = []
-
-    return to_transform_instances(augment)
-
-
-def make_iterator(
-    dataloader: grain.DataLoader,
-    operations: List[grain.Transformation],
-    seed: int,
-):
-    n_gpus = jax.device_count()
-    devices = mesh_utils.create_device_mesh((n_gpus,))
-
-    # replicate initial params on all devices, shard data batch over devices
-    mesh = Mesh(devices, ("ensemble",))
-    named_sharding = NamedSharding(mesh, P("ensemble"))
-
-    @jax.jit
-    @partial(
-        shard_map,
-        mesh=mesh,
-        in_specs=(P(None), P("ensemble")),
-        out_specs=P("ensemble"),
-    )
-    def main_transform(key: jax.Array, batch):
-
-        key = jax.random.fold_in(key, jax.lax.axis_index("ensemble"))
-
-        for transform in operations:
-            if isinstance(transform, grain.RandomMapTransform):
-                key, subkey = random.split(key)
-                batch = transform.random_map(batch, subkey)
-            elif isinstance(transform, grain.MapTransform):
-                batch = transform.map(batch)
-            elif hasattr(transform, "np_random_map"):  # TfRandomMapTransform
-                key, subkey = random.split(key)
-                batch = transform.np_random_map(batch, subkey)
-            else:
-                raise ValueError(f"Unknown operation type: {type(transform)}")
-        return batch
-
-    key = random.PRNGKey(seed)
-
-    for batch in dataloader:
-
-        # move numpy data to sharded
-        batch_out = jax.device_put(batch, named_sharding)
-
-        key, subkey = random.split(key)
-
-        batch_out = main_transform(subkey, batch_out)
-
-        yield batch_out
-
-
-def prefetch_to_device(iterator, size):
-    """Shard and prefetch batches on device.
-
-    This is a variation of https://flax.readthedocs.io/en/latest/api_reference/flax.jax_utils.html#flax.jax_utils.prefetch_to_device
-
-    This utility takes an iterator and returns a new iterator which fills an on
-    device prefetch buffer. Eager prefetching can improve the performance of
-    training loops significantly by overlapping compute and data transfer.
-
-    This utility is mostly useful for GPUs, for TPUs and CPUs it should not be
-    necessary -- the TPU & CPU memory allocators (normally) don't pick a memory
-    location that isn't free yet so they don't block. Instead those allocators OOM.
-
-    Args:
-      iterator: an iterator that yields a pytree of ndarrays where the first
-        dimension is sharded across devices.
-
-      size: the size of the prefetch buffer.
-
-        If you're training on GPUs, 2 is generally the best choice because this
-        guarantees that you can overlap a training step on GPU with a data
-        prefetch step on CPU.
-
-    Yields:
-      The original items from the iterator where each ndarray is now sharded to
-      the specified devices.
-
-    Reference:
-    https://flax.readthedocs.io/en/latest/api_reference/flax.jax_utils.html#flax.jax_utils.prefetch_to_device
-    """
-    queue = collections.deque()
-
-    def enqueue(n):  # Enqueues *up to* `n` elements from the iterator.
-        for data in itertools.islice(iterator, n):
-            queue.append(data)
-
-    enqueue(size)  # Fill up the buffer.
-    while queue:
-        yield queue.popleft()
-        enqueue(1)
 
 
 @argbind.bind("train", "val", "test", "sample")
@@ -161,10 +25,8 @@ def create_dataset(
     seed: int = 0,
     worker_count: int = 0,
     worker_buffer_size: int = 2,
-    prefetch_size: int = 2,
-    enable_profiling: bool = False,  # todo: haven't gotten it to work with True
+    enable_profiling: int = 0,  # bool
     num_epochs: int = 1,  # for train/val use 1, but for sample set it to None so that it loops forever.
-    post_transforms: List[grain.Transformation] = None,
 ):
 
     assert sources is not None
@@ -179,7 +41,6 @@ def create_dataset(
             duration=duration,
             extensions=extensions,
             saliency_params=SaliencyParams(),  # rely on argbind,
-            cpu=True,
         )
     else:
         datasource = AudioDataSimpleSource(
@@ -189,14 +50,7 @@ def create_dataset(
             mono=mono,
             duration=duration,
             extensions=extensions,
-            cpu=True,
         )
-
-    if worker_count is None or worker_count > 1:
-        true_num_steps = (
-            len(datasource) // batch_size
-        )  # floor since the batch mode is `drop_remainder`
-        assert true_num_steps > 1, "This is an edge case."
 
     shard_options = grain.NoSharding()  # todo:
 
@@ -204,10 +58,7 @@ def create_dataset(
         num_records=len(datasource),
         num_epochs=num_epochs,
         shard_options=shard_options,
-        # Keep shuffling off for training, which uses AudioDataBalancedSource.
-        # AudioDataBalancedSource already does the shuffling deterministically, and turning it on
-        # here would actually BREAK the locality of the balancing between batches.
-        shuffle=not train,
+        shuffle=bool(train),
         seed=seed,
     )
 
@@ -216,28 +67,17 @@ def create_dataset(
         ReduceBatchTransform(sample_rate),
     ]
 
-    tmp_dataloader = grain.DataLoader(
+    dataloader = grain.DataLoader(
         data_source=datasource,
         sampler=index_sampler,
         operations=pygrain_ops,
         worker_count=worker_count,
         worker_buffer_size=worker_buffer_size,
         shard_options=shard_options,
-        enable_profiling=enable_profiling,
+        enable_profiling=bool(enable_profiling),
     )
 
-    operations = build_transforms()
-    if post_transforms is not None:
-        operations += post_transforms
-
-    batched_dataloader = make_iterator(
-        tmp_dataloader, operations, seed=seed + 1
-    )
-
-    if prefetch_size is not None and prefetch_size > 1:
-        batched_dataloader = prefetch_to_device(batched_dataloader, size=prefetch_size)
-
-    return batched_dataloader
+    return dataloader
 
 
 if __name__ == "__main__":
@@ -263,7 +103,7 @@ if __name__ == "__main__":
         duration=0.5,
         train=True,
         batch_size=32,
-        sample_rate=44100,
+        sample_rate=44_100,
         mono=True,
         seed=0,
         num_steps=num_steps,

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,15 +32,14 @@ packages = find:
 python_requires = >=3.9
 install_requires =
     argbind @ git+https://github.com/DBraun/argbind.git@improve.subclasses
-    audiotree>=0.1.0
+    audiotree>=0.2.0
     audiocraft
-    chex>=0.1.86
     clu>=0.0.12
     dm_aux @ git+https://github.com/DBraun/dm_aux.git@DBraun-patch-2
     einops>=0.8.0
-    flax>=0.8.2
     grain>=0.1.0
-    jaxloudnorm @ git+https://github.com/DBraun/jaxloudnorm.git@feature/speed-optimize
+    jax-ai-stack>=2025.1.9
+    jaxloudnorm @ git+https://github.com/boris-kuz/jaxloudnorm.git
     librosa>=0.10.1
     omegaconf
     tqdm>=4.66.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ version = attr: dac_jax.__version__
 url = https://github.com/DBraun/DAC-JAX
 author = David Braun
 author_email = braun@ccrma.stanford.edu
-description = Descript Audio Codec in JAX.
+description = Descript Audio Codec and EnCodec in JAX.
 long_description = file: README.md
 long_description_content_type = "text/markdown"
 keywords =
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Artistic Software
     Topic :: Multimedia
     Topic :: Multimedia :: Sound/Audio
@@ -37,8 +38,8 @@ install_requires =
     clu>=0.0.12
     dm_aux @ git+https://github.com/DBraun/dm_aux.git@DBraun-patch-2
     einops>=0.8.0
-    grain>=0.1.0
-    jax-ai-stack>=2025.1.9
+    grain==0.2.*
+    jax-ai-stack>=2025.2.5
     jaxloudnorm @ git+https://github.com/boris-kuz/jaxloudnorm.git
     librosa>=0.10.1
     omegaconf

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ license = MIT
 classifiers =
     Intended Audience :: Developers
     Natural Language :: English
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -30,7 +29,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     argbind @ git+https://github.com/DBraun/argbind.git@improve.subclasses
     audiotree>=0.2.0

--- a/src/dac_jax/model/dac.py
+++ b/src/dac_jax/model/dac.py
@@ -211,7 +211,7 @@ class Encoder(nn.Module):
 
         # Wrap black into nn.Sequential
         block = nn.Sequential(block)
-        x = rearrange(x, "b c l -> b l c")
+        x = rearrange(x, "b c l -> b l c", c=1)
         x = block(x)
         return x
 


### PR DESCRIPTION
We now use `audiotree==0.2.0`. The usage of `shard_map` and grain have been improved. The data augmentations take place inside `train_step` and `eval_step` and therefore are jitted.